### PR TITLE
feat: add makefile filetype detection

### DIFF
--- a/lua/epics.lua
+++ b/lua/epics.lua
@@ -95,24 +95,9 @@ local function register_ftdetect()
 						return "streamdevice_proto"
 					end
 				end
-			end
-		}
-	})
-end
+			end,
 
-function M.setup(opts)
-	vim.validate { opts = { opts, "table" } }
-
-	for given_key, _ in pairs(opts) do
-		if not M.options[given_key] then
-			error("Unsupported epics.nvim option: " .. given_key)
-		end
-	end
-
-	M.options = vim.tbl_extend("force", M.options, opts)
-
-	vim.filetype.add {
-		extension = {
+			-- for makefile
 			ioc = "make",
 			Db = "make",
 		},
@@ -134,7 +119,20 @@ function M.setup(opts)
 			[".*/cfg/TOOLCHAIN.*"] = "make",
 			[".*/cfg/TOP_RULES.*"] = "make",
 		},
-	}
+	})
+end
+
+function M.setup(opts)
+	vim.validate { opts = { opts, "table" } }
+
+	for given_key, _ in pairs(opts) do
+		if not M.options[given_key] then
+			error("Unsupported epics.nvim option: " .. given_key)
+		end
+	end
+
+	M.options = vim.tbl_extend("force", M.options, opts)
+
 	register_treesitter_grammars()
 	register_ftdetect()
 end

--- a/lua/epics.lua
+++ b/lua/epics.lua
@@ -127,7 +127,12 @@ function M.setup(opts)
 			[".*/configure/os/CONFIG.*"] = "make",
 			[".*/configure/CONFIG.*"] = "make",
 			[".*/configure/RULES.*"] = "make",
-			[".*/configure/RELEASE"] = "make",
+			[".*/configure/RELEASE.*"] = "make",
+			[".*/cfg/CONFIG.*"] = "make",
+			[".*/cfg/DIR_RULES.*"] = "make",
+			[".*/cfg/RULES.*"] = "make",
+			[".*/cfg/TOOLCHAIN.*"] = "make",
+			[".*/cfg/TOP_RULES.*"] = "make",
 		},
 	}
 	register_treesitter_grammars()

--- a/lua/epics.lua
+++ b/lua/epics.lua
@@ -111,6 +111,25 @@ function M.setup(opts)
 
 	M.options = vim.tbl_extend("force", M.options, opts)
 
+	vim.filetype.add {
+		extension = {
+			ioc = "make",
+			Db = "make",
+		},
+		filename = {
+			["RULES.Db"] = "make",
+			["RULES.ioc"] = "make",
+			["CONFIG_STIE"] = "make",
+			["CONFIG_STIE.local"] = "make",
+			["CONFIG_STIE_ENV"] = "make",
+		},
+		pattern = {
+			[".*/configure/os/CONFIG.*"] = "make",
+			[".*/configure/CONFIG.*"] = "make",
+			[".*/configure/RULES.*"] = "make",
+			[".*/configure/RELEASE"] = "make",
+		},
+	}
 	register_treesitter_grammars()
 	register_ftdetect()
 end

--- a/lua/epics.lua
+++ b/lua/epics.lua
@@ -104,9 +104,9 @@ local function register_ftdetect()
 		filename = {
 			["RULES.Db"] = "make",
 			["RULES.ioc"] = "make",
-			["CONFIG_STIE"] = "make",
-			["CONFIG_STIE.local"] = "make",
-			["CONFIG_STIE_ENV"] = "make",
+			["CONFIG_SITE"] = "make",
+			["CONFIG_SITE.local"] = "make",
+			["CONFIG_SITE_ENV"] = "make",
 		},
 		pattern = {
 			[".*/configure/os/CONFIG.*"] = "make",

--- a/lua/epics.lua
+++ b/lua/epics.lua
@@ -96,10 +96,6 @@ local function register_ftdetect()
 					end
 				end
 			end,
-
-			-- for makefile
-			ioc = "make",
-			Db = "make",
 		},
 		filename = {
 			["RULES.Db"] = "make",


### PR DESCRIPTION
There're many makefile file named in other names instead of `makefile`.

Use `filename` and `pattern` matching to set filetype to `make`.